### PR TITLE
Add unit test and integration test

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,8 @@
+node_modules/
+test/
+dist/
+doc/
+**/*.min.js
+**/*-min.js
+**/*.bundle.js
+jest.*

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  extends: 'eslint-config-ali/typescript',
+  root: true,
+  env: {
+    node: true,
+    jest: true,
+  },
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: Serverless Devs Project CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   ci:
@@ -17,21 +17,22 @@ jobs:
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/
-      - name: NPM install
+      - name: install dependencies
         run: |
           npm install
-      - name: NPM install s
+      - name: install s
         run: |
           npm install -g @serverless-devs/s
-      - name: NPM run lint
+      - name: lint
         run: |
           npm run lint
-      - name: NPM run lint
+      - name: unit test 
         run: |
           npm run test
-      - name: EXPROT secrets
-        run: |
-          export AccountID=${{secrets.AccountID}} AccessKeyID=${{secrets.AccessKeyID}} AccessKeySecret=${{secrets.AccessKeySecret}}
-      - name: NPM run test-integration
+      - name: integration test
+        env:
+          AccountID: ${{secrets.ACCOUNTID}}
+          AccessKeyID: ${{secrets.ACCESSKEYID}}
+          AccessKeySecret: ${{secrets.ACCESSKEYSECRET}}
         run: |
           npm run test-integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: Serverless Devs Project CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - name: NPM install
+        run: |
+          npm install
+      - name: NPM install s
+        run: |
+          npm install -g @serverless-devs/s
+      - name: NPM run lint
+        run: |
+          npm run lint
+      - name: NPM run lint
+        run: |
+          npm run test
+      - name: EXPROT secrets
+        run: |
+          export AccountID=${{secrets.AccountID}} AccessKeyID=${{secrets.AccessKeyID}} AccessKeySecret=${{secrets.AccessKeySecret}}
+      - name: NPM run test-integration
+        run: |
+          npm run test-integration

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ package-lock.json
 .vscode
 package-lock.json
 lib/
+.env
+coverage

--- a/.signore
+++ b/.signore
@@ -9,3 +9,5 @@ package-lok.json
 .github
 
 ./example
+.env
+coverage

--- a/f2elint.config.js
+++ b/f2elint.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  enableStylelint: false,
+  enableMarkdownlint: false,
+};

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,14 @@
+/*
+ * For a detailed explanation regarding each configuration property and type check, visit:
+ * https://jestjs.io/docs/en/configuration.html
+ */
+
+export default {
+  coverageDirectory: 'coverage',
+  coverageProvider: 'v8',
+  collectCoverage: false,
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/test/*.test.ts'],
+  setupFilesAfterEnv: ['./jest.setup.ts'],
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+jest.setTimeout(5 * 60 * 1000);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,13 @@
   "scripts": {
     "start": "npm run watch",
     "watch": "npm run doc && tsc -w",
-    "build": "rm -rf node_modules && rm -rf package-lock.json && npm i && ncc build src/index.ts -m -e @serverless-devs/core -o lib",
+    "prebuild": "rm -rf node_modules && rm -rf package-lock.json && npm i && rimraf lib",
+    "build": "npm run fix && npm run lint && ncc build src/index.ts -m -e @serverless-devs/core -o lib",
+    "lint": "f2elint scan",
+    "fix": "f2elint fix",
+    "test": "jest --testNamePattern '^(?!Integration::)'",
+    "test-integration": "jest --testNamePattern ^Integration::",
+    "test:cov": "jest --coverage",
     "doc": "npx typedoc src/index.ts --json doc/doc.json --out doc"
   },
   "dependencies": {
@@ -36,12 +42,26 @@
   },
   "devDependencies": {
     "@types/node": "^14.0.23",
-    "@typescript-eslint/eslint-plugin": "^3.10.0",
-    "@typescript-eslint/parser": "^3.10.0",
     "@zeit/ncc": "^0.22.3",
+    "@types/eslint": "^7.2.6",
+    "@types/jest": "^26.0.10",
+    "@types/node": "^14.0.23",
+    "dotenv": "^10.0.0",
     "eslint": "^7.7.0",
+    "f2elint": "^0.4.4",
+    "jest": "^26.4.0",
+    "sinon": "^5.0.7",
+    "ts-jest": "^26.2.0",
     "ts-node": "^8.10.2",
+    "jest": "^26.4.0",
+    "sinon": "^5.0.7",
+    "ts-jest": "^26.2.0",
+    "@types/jest": "^26.0.10",
     "typedoc": "^0.20.35",
     "typescript": "^3.9.7"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,17 +35,17 @@
     "doc": "npx typedoc src/index.ts --json doc/doc.json --out doc"
   },
   "dependencies": {
+    "@alicloud/fc2": "^2.2.2",
     "@serverless-devs/core": "^0.0.*",
+    "ali-oss": "^6.16.0",
     "js-yaml": "^4.0.0",
-    "lodash": "^4.17.21",
-    "@alicloud/fc2": "^2.2.2"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@types/node": "^14.0.23",
-    "@zeit/ncc": "^0.22.3",
     "@types/eslint": "^7.2.6",
     "@types/jest": "^26.0.10",
     "@types/node": "^14.0.23",
+    "@zeit/ncc": "^0.22.3",
     "dotenv": "^10.0.0",
     "eslint": "^7.7.0",
     "f2elint": "^0.4.4",
@@ -53,10 +53,6 @@
     "sinon": "^5.0.7",
     "ts-jest": "^26.2.0",
     "ts-node": "^8.10.2",
-    "jest": "^26.4.0",
-    "sinon": "^5.0.7",
-    "ts-jest": "^26.2.0",
-    "@types/jest": "^26.0.10",
     "typedoc": "^0.20.35",
     "typescript": "^3.9.7"
   },

--- a/publish.yaml
+++ b/publish.yaml
@@ -49,3 +49,10 @@ Properties:
     Default: ''
     Type:
       - String
+  triggerName:
+    Description: 
+    required: false
+    Example: trigger-name
+    Default: ''
+    Type:
+      - String

--- a/publish.yaml
+++ b/publish.yaml
@@ -1,10 +1,51 @@
 Type: Component
 Name: fc-info
-Provider:
-  - 其它
 Version: 0.0.12
-Description: 初始化component模板
-HomePage: https://www.serverless-devs.com
-Tags: #标签详情
-  - 模板
-Category: 其它
+Category: 基础云产品
+HomePage: 'https://github.com/devsapp/fc'
+Tags:
+  - 函数计算
+Description: 阿里云函数计算基础组件
+Commands:
+  info: 用于获取远端函数计算资源
+Properties:
+  region:
+    Description: 地区
+    Required: true
+    Example: cn-shenzhen
+    Default: ''
+    Type:
+      - Enum:
+        - cn-beijing
+        - cn-hangzhou
+        - cn-shanghai
+        - cn-qingdao
+        - cn-zhangjiakou
+        - cn-huhehaote
+        - cn-shenzhen
+        - cn-chengdu
+        - cn-hongkong
+        - ap-southeast-1
+        - ap-southeast-2
+        - ap-southeast-3
+        - ap-southeast-5
+        - ap-northeast-1
+        - eu-central-1
+        - eu-west-1
+        - us-west-1
+        - us-east-1
+        - ap-south-1
+  serviceName:
+    Description: 服务名称
+    Required: true
+    Example: service-name
+    Default: ''
+    Type:
+      - String
+  functionName:
+    Description: 函数名称
+    Required: false
+    Example: function-name
+    Default: ''
+    Type:
+      - String

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,10 @@ export default class FcInfoComponent {
     // if (!access) {
     //   throw new Error(`You must provide access.`);
     // }
-    const credential: ICredentials = await core.getCredential(access);
+    let credential: ICredentials = inputs?.credentials;
+    if (_.isEmpty(credential)) {
+      credential = await core.getCredential(access);
+    }
     await this.report('fc-info', 'info', credential.AccountID, access);
     if (parsedArgs.isHelp) {
       core.help(INFO_HELP_INFO);

--- a/test/index-integration.test.ts
+++ b/test/index-integration.test.ts
@@ -1,0 +1,102 @@
+import _ from 'lodash';
+import FC from '@alicloud/fc2';
+import path from 'path';
+import dotenv from 'dotenv';
+import fs from 'fs-extra';
+import { exec } from 'child_process';
+import ComponentStarter from '../src/index';
+
+describe('Integration::command', () => {
+  dotenv.config();
+
+  const name = 'fc-info-testsuite'
+  const serviceName = `service-${new Date().getTime()}-${Math.random().toString(36).substr(2)}`
+  const funcName = `func-${new Date().getTime()}-${Math.random().toString(36).substr(2)}`
+  //const triggerName = `trigger-${new Date().getTime()}-${Math.random().toString(36).substr(2)}`
+
+  const inputs = {
+    props: {
+      region: 'cn-shenzhen',
+      serviceName: serviceName,
+      functionName: funcName,
+    },
+    credentials: {
+      AccountID: process.env.AccountID,
+      AccessKeyID: process.env.AccessKeyID,
+      AccessKeySecret: process.env.AccessKeySecret,
+    },
+    appName: 'fc-info-test',
+    project: {
+      component: 'devsapp/fc-info',
+      access: 'test',
+      projectName: 'test',
+    },
+    command: '',
+    args: '--region',
+    path: {
+      configPath: path.join(process.cwd(), '..', 'example', 's.yaml'),
+    },
+  };
+
+  const client = new FC(process.env.AccountID, {
+      accessKeyID: process.env.AccessKeyID,
+      accessKeySecret: process.env.AccessKeySecret, 
+      region: 'cn-shenzhen',
+  });
+
+  beforeAll(async () => {
+    await exec(`s config add --AccountID ${process.env.AccountID} --AccessKeyID ${process.env.AccessKeyID} --AccessKeySecret ${process.env.AccessKeySecret} -a ${name}`);
+    // create service
+   try {
+      await client.createService(serviceName);
+
+   } catch (err) {
+      console.error(err);
+    }
+  });
+
+  afterAll(async () => {
+    await exec(`s config delete -a ${name}`);
+    fs.removeSync(path.join(process.cwd(), '.s'));
+
+    // remove service
+    try {
+      await client.deleteService(serviceName);
+    } catch (err) {
+      console.error(err);
+    }
+  })
+
+  // no trigger
+  it('info info', async () => {
+    const zipFile = 'UEsDBAoAAAAIABULiFLOAhlFSQAAAE0AAAAIAAAAaW5kZXguanMdyMEJwCAMBdBVclNBskCxuxT9UGiJNgnFg8MX+o4Pc3R14/OQdkOpUFQ8mRQ2MtUujumJyv4PG6TFob3CjCEve78gtBaFkLYPUEsBAh4DCgAAAAgAFQuIUs4CGUVJAAAATQAAAAgAAAAAAAAAAAAAALSBAAAAAGluZGV4LmpzUEsFBgAAAAABAAEANgAAAG8AAAAAAA==';
+    await client.createFunction(serviceName, {
+          functionName: funcName,
+	  handler: 'index.handler',
+          memorySize: 128,
+          runtime: 'nodejs12',
+          code: {
+            zipFile,
+	  },
+    });
+ 
+    const inp = _.cloneDeep(inputs);
+    inp.args = 'info';
+    const componentStarter = new ComponentStarter();
+    const result = await componentStarter.info(inp);
+    expect(Object.keys(result)).toEqual(['service','function',]);
+
+    try {
+      await client.deleteFunction(serviceName, funcName);
+    } catch(err) { console.log(err); }
+  });
+
+  it('info help', async () => {
+    const inp = _.cloneDeep(inputs);
+    inp.args = '--help';
+    const componentStarter = new ComponentStarter();
+    const result = await componentStarter.info(inp);
+    console.log('fc-info help: ', result);
+    expect(result).toBeUndefined();
+  });
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,0 +1,81 @@
+import _ from 'lodash';
+import path from 'path';
+import ComponentStarter from '../src/index';
+import sinon from 'sinon';
+import fse from 'fs-extra';
+import FC from '@alicloud/fc2';
+
+const sandbox = sinon.createSandbox();
+const componentStarter = new ComponentStarter();
+
+const name = 'testSuite';
+const dir = './test/testInfo/';
+const inputs = {
+  props: {
+    region: 'cn-shenzhen',
+    serviceName: name,
+    functionName: name,
+  },
+  credentials: {
+    AccountID: 'AccountID',
+    AccessKeyID: 'AccessKeyID',
+    AccessKeySecret: 'AccessKeySecret',
+  },
+  appName: 'fc-info-test',
+  project: {
+    component: 'devsapp/fc-info',
+    access: 'test',
+    projectName: 'test',
+  },
+  command: '',
+  args: '--region',
+  path: {
+    configPath: path.join(process.cwd(), '..', 'example', 's.yaml'),
+  },
+};
+
+describe('test/index.test.ts', () => {
+  beforeEach(async () => {
+    sandbox.stub(FC.prototype, 'getService').resolves({
+      data: { name },
+    });
+    sandbox.stub(FC.prototype, 'listFunctions').resolves({
+      data: { functions: [{ name }],
+    } });
+    sandbox.stub(FC.prototype, 'getFunction').resolves({
+      data: { functionName: name },
+    });
+    sandbox.stub(FC.prototype, 'getFunctionCode').resolves({
+      data: { url: 'https://registry.devsapp.cn/simple/devsapp/fc-info/zipball/0.0.11' }
+    });
+    sandbox.stub(FC.prototype, 'listTriggers').resolves({
+      data: { triggers: [{ name }] },
+    });
+    sandbox.stub(FC.prototype, 'getTrigger').resolves({
+      data: {
+        triggerName: 'http',
+        triggerType: 'http',
+        triggerConfig: {},
+      },
+    });
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+    await fse.remove(dir);
+  });
+
+  it('info info', async () => {
+    const inp = _.cloneDeep(inputs);
+    inp.args = 'info';
+    const result = await componentStarter.info(inp);
+    expect(Object.keys(result)).toEqual(['service', 'function', 'triggers']);
+  });
+
+  it('info help', async () => {
+    const inp = _.cloneDeep(inputs);
+    inp.args = `--help`;
+    const result = await componentStarter.info(inp);
+    expect(result).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Description

* Add unit tests and integration tests for fc-info
* Integration test included http and oss trigger
* Update publish.yaml with new properties (regions, service name, etc.)
* Update package.json with jest dependencies
* Remove interactive credential checking due to non-interactive test environment

#### Note: this mr is based on comments from #15 and #14 

## Steps

```
npm install
npm test
npm run test-integration
```

## Expected output

![image](https://user-images.githubusercontent.com/23239892/130613890-0ec92b98-8e84-46cf-8e5c-c49ebe60527b.png)

